### PR TITLE
fix: convert Python booleans to valid Python literals in Kestra.outputs()

### DIFF
--- a/python/src/kestra.py
+++ b/python/src/kestra.py
@@ -115,6 +115,16 @@ class Kestra:
         )
 
     @staticmethod
+    def _convert_booleans(obj: Any) -> Any:
+        if isinstance(obj, bool):
+            return str(obj)
+        elif isinstance(obj, dict):
+            return {k: Kestra._convert_booleans(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [Kestra._convert_booleans(item) for item in obj]
+        return obj
+
+    @staticmethod
     def outputs(map_: dict):
         """
         The `Kestra` class provides a method to send key-value-based outputs to
@@ -122,10 +132,14 @@ class Kestra:
         file and specify them within the `outputFiles` property of the Python
         script task.
 
+        Boolean values are automatically converted to their Python string
+        representation ('True' or 'False') to prevent a NameError when
+        referenced in downstream Python tasks via Pebble expressions.
+
         Args:
             map_ (dict): The outputs to send to the Kestra server.
         """
-        Kestra._send({"outputs": map_})
+        Kestra._send({"outputs": Kestra._convert_booleans(map_)})
 
     @staticmethod
     def assets(map_: dict):

--- a/python/src/kestra.py
+++ b/python/src/kestra.py
@@ -135,6 +135,14 @@ class Kestra:
         Boolean values are automatically converted to their Python string
         representation ('True' or 'False') to prevent a NameError when
         referenced in downstream Python tasks via Pebble expressions.
+        
+        Example:
+            >>> import json
+            >>> results = []
+            >>> Kestra._send = lambda x: results.append(x)
+            >>> Kestra.outputs({'flag': True, 'count': 3, 'name': 'test'})
+            >>> results[0]
+            {'outputs': {'flag': 'True', 'count': 3, 'name': 'test'}}
 
         Args:
             map_ (dict): The outputs to send to the Kestra server.


### PR DESCRIPTION
Related to https://github.com/kestra-io/plugin-scripts/issues/191

## Problem
When `Kestra.outputs()` is called with a Python boolean, `json.dumps` serializes it as JSON `true`/`false`. When a downstream Python task references it via `{{outputs.task.vars.my_bool}}`, Pebble renders it as `true` — not a valid Python identifier, causing a `NameError` in the downstream task.

## Fix
Added `_convert_booleans()` that recursively converts `bool` values to `"True"`/`"False"` strings before serialization. All other types are unaffected.

## Files Changed
- `python/src/kestra.py` — added `_convert_booleans()`, updated `outputs()` to call it

Here are the screenshots proving the fix works.
Video: Both tasks passing successfully with the fix applied.


https://github.com/user-attachments/assets/4b55c694-7463-4bdd-af82-ad232a058a4e


Screenshot 2: Outputs tab showing scraping_successful correctly rendered as True (valid Python literal) instead of true (JSON boolean).

<img width="1919" height="1013" alt="Screenshot 2026-03-17 222544" src="https://github.com/user-attachments/assets/c136a247-c21b-4844-aeb6-23864487b53f" />